### PR TITLE
Alter terms selection (for mrgtest only) to aid integration testing for MRGT

### DIFF
--- a/docs/tev2/saf.yaml
+++ b/docs/tev2/saf.yaml
@@ -44,7 +44,7 @@ scopes:  #
 versions:
   - vsntag: mrgtest # this version MUST only be used for testing the MRG generator
     terms:
-    - "[tev2]@tev2" # import all tev2 terms.
+    - "*@tev2" # import all tev2 terms.
   - vsntag: 0x921456 # a versiontag that identifies this version from all other versions in the SAF
     altvsntags: # alternative verstiontags
     - latest


### PR DESCRIPTION
@RieksJ I have altered the term selection based on what I think is our latest version (using * for all rather than the scopetag). I've only done this for the mrgtest version for the moment but happy to alter the others if you'd like