### PR TITLE
Remove brackets for <scopetag>:<version> in termselcrit to maintain consistency and simplify syntax

### DIFF
--- a/docs/tev2/saf.yaml
+++ b/docs/tev2/saf.yaml
@@ -55,7 +55,7 @@ versions:
     - v0.9.4
   termselcrit:
     - "tags[management]@essif-lab" # import all terms from the mrg of `essif-lab:latest` that have grouptag `management`.
-    - "termids[party,community](@essif-lab:0.9.4)" # import the terms `party` and `community` from the mrg of `essif-lab:0.9.4`.
+    - "termids[party,community]@essif-lab:0.9.4" # import the terms `party` and `community` from the mrg of `essif-lab:0.9.4`.
     - "*@tev2" # import all terms defined in the scope `tev2`
   status: proposed
   from: 20220312


### PR DESCRIPTION
Instead of having the scopetag:version sometimes in brackets remove these to both simplify and make consistent


Signed-off-by: Sid Haniff <syed_haniff@hotmail.com>